### PR TITLE
Add support for lmstudio cli with a modular LLM backend 

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,29 @@ And you will get commented spell casts that you can incrementally modify like be
 
 ## Caveats - A Little Magic Caution ⚠️
 
-Zummoner can use either [Simon w's llm](https://github.com/simonw/llm) or DAY50's [llcat](https://github.com/day50-dev/llcat).
+Zummoner can use either [Simon w's llm](https://github.com/simonw/llm), [LMStudio](https://lmstudio.ai/), or DAY50's [llcat](https://github.com/day50-dev/llcat).
 
-For `llcat` set the: 
+For `llcat` set the:
   * model with `LLC_MODEL`
   * server with `LLC_SERVER`
   * key with `LLC_KEY`
   * mcpfile (if you want) with `LLC_MCP`
+
+For LMStudio, set the model with `LMS_MODEL` (optional - defaults to first available model):
+  ```bash
+  LMS_MODEL="local-model-name"
+  ```
+
+### Backend Selection
+
+By default, Zummoner auto-detects backends in priority order: llcat > lms > llm. You can override this:
+
+  ```bash
+  ZUMMONER_BACKEND=auto    # Auto-detect (default)
+  ZUMMONER_BACKEND=llcat   # Force llcat
+  ZUMMONER_BACKEND=llm     # Force Simonw's llm
+  ZUMMONER_BACKEND=lms     # Force LMStudio CLI
+  ```
 
 
 There's also bummoner.sh in here which is the bash version of zummoner.

--- a/bummoner.bash
+++ b/bummoner.bash
@@ -1,3 +1,106 @@
+# LLM Backend System for Bummoner
+# Supports: llcat, lms, llm
+
+# ============================================================
+# llcat backend
+# ============================================================
+_ll_backend_llcat_detect() {
+  which llcat >& /dev/null
+}
+
+_ll_backend_llcat_model() {
+  echo "$LLC_MODEL"
+}
+
+_ll_backend_llcat_invoke() {
+  local model="$1"
+  local prompt="$2"
+  llcat -k "$LLC_KEY" -u "$LLC_SERVER" ${LLC_MCP:+-mf "$LLC_MCP"} -m "$model" "$prompt"
+}
+
+# ============================================================
+# lms backend (LMStudio CLI)
+# ============================================================
+_ll_backend_lms_detect() {
+  which lms >& /dev/null
+}
+
+_ll_backend_lms_model() {
+  if [[ -n "$LMS_MODEL" ]]; then
+    echo "$LMS_MODEL"
+  else
+    lms ls 2>/dev/null | head -n 1
+  fi
+}
+
+_ll_backend_lms_invoke() {
+  local model="$1"
+  local prompt="$2"
+  if [[ -z "$model" ]]; then
+    echo "Error: No model specified. Set LMS_MODEL or load a model in LMStudio." >&2
+    return 1
+  fi
+  lms chat "$model" -p "$prompt"
+}
+
+# ============================================================
+# llm backend (Simonw's llm)
+# ============================================================
+_ll_backend_llm_detect() {
+  which llm >& /dev/null
+}
+
+_ll_backend_llm_model() {
+  if [[ -r "$HOME/.config/io.datasette.llm/default_model.txt" ]]; then
+    cat "$HOME/.config/io.datasette.llm/default_model.txt"
+  else
+    llm models default
+  fi
+}
+
+_ll_backend_llm_invoke() {
+  local model="$1"
+  local prompt="$2"
+  llm -m "$model" "$prompt"
+}
+
+# ============================================================
+# Backend auto-selection
+# ============================================================
+_ll_select_backend() {
+  # If user specified a backend, use it
+  if [[ -n "$ZUMMONER_BACKEND" && "$ZUMMONER_BACKEND" != "auto" ]]; then
+    if _ll_backend_${ZUMMONER_BACKEND}_detect 2>/dev/null; then
+      echo "$ZUMMONER_BACKEND"
+      return 0
+    fi
+    return 1
+  fi
+
+  # Otherwise auto-detect by priority
+  for backend in llcat llm lms; do
+    if _ll_backend_${backend}_detect 2>/dev/null; then
+      echo "$backend"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Get model for selected backend
+_ll_get_model() {
+  local backend="$1"
+  _ll_backend_${backend}_model
+}
+
+# Invoke LLM with model and prompt
+_ll_invoke() {
+  local backend="$1"
+  local model="$2"
+  local prompt="$3"
+  _ll_backend_${backend}_invoke "$model" "$prompt"
+}
+
 bummoner() {
   local QUESTION="${READLINE_LINE:-}"
   local PROMPT="
@@ -29,23 +132,18 @@ bummoner() {
   other formatting. Do not include the command into a code block.
   Don't include the shell itself (bash, zsh, etc.) in the command.
   "
-  if which llcat >& /dev/null; then
-    alias _ll="llcat -k $LLC_KEY -u $LLC_SERVER"
-    [[ -n "$LLC_MCP" ]] && _ll="$_ll -mf $LLC_MCP"
-    model="$LLC_MODEL"
-  else
-    alias _ll="llm"
 
-    if [[ -r "$HOME/$config/io.datasette.llm/default_model.txt" ]]; then
-      model=$(cat "$HOME/$config/io.datasette.llm/default_model.txt")
-    else
-      model=$(llm models default)
-    fi
-  fi
+  # Auto-detect and select backend
+  local backend=$(_ll_select_backend) || {
+    READLINE_LINE="No LLM backend found (llcat, lms, or llm)"
+    return 1
+  }
+
+  local model=$(_ll_get_model "$backend")
 
   echo ""
   echo "$QUESTION ... $model"
-  local response=$(_ll -m "$model" "$PROMPT")
+  local response=$(_ll_invoke "$backend" "$model" "$PROMPT")
   local COMMAND=$(echo "$response" | sed 's/```//g' | tr -d '\n')
   if [[ -n "$COMMAND" ]]; then
     if [[ -n "$ZUMMONER_SPELL" ]]; then

--- a/zummoner.zsh
+++ b/zummoner.zsh
@@ -1,3 +1,108 @@
+# LLM Backend System for Zummoner
+# Supports: llcat, lms, llm
+
+# ============================================================
+# llcat backend
+# ============================================================
+_ll_backend_llcat_detect() {
+  which llcat >& /dev/null
+}
+
+_ll_backend_llcat_model() {
+  echo "$LLC_MODEL"
+}
+
+_ll_backend_llcat_invoke() {
+  local model="$1"
+  local prompt="$2"
+  llcat -k "$LLC_KEY" -u "$LLC_SERVER" ${LLC_MCP:+-mf "$LLC_MCP"} -m "$model" "$prompt"
+}
+
+# ============================================================
+# lms backend (LMStudio CLI)
+# ============================================================
+_ll_backend_lms_detect() {
+  which lms >& /dev/null
+}
+
+_ll_backend_lms_model() {
+  if [[ -n "$LMS_MODEL" ]]; then
+    echo "$LMS_MODEL"
+  else
+    lms ls 2>/dev/null | head -n 1
+  fi
+}
+
+_ll_backend_lms_invoke() {
+  local model="$1"
+  local prompt="$2"
+  if [[ -z "$model" ]]; then
+    echo "Error: No model specified. Set LMS_MODEL or load a model in LMStudio." >&2
+    return 1
+  fi
+  NO_COLOR=1 lms chat "$model" -p "$prompt" 2>/dev/null \
+    | sed -E 's/\x1b(\[[0-9;?]*[A-Za-z]|\][^\a]*(\a|\x1b\\)|[^[])//g' \
+    | tr -d '\r'
+}
+
+# ============================================================
+# llm backend (Simonw's llm)
+# ============================================================
+_ll_backend_llm_detect() {
+  which llm >& /dev/null
+}
+
+_ll_backend_llm_model() {
+  if [[ -r "$HOME/.config/io.datasette.llm/default_model.txt" ]]; then
+    cat "$HOME/.config/io.datasette.llm/default_model.txt"
+  else
+    llm models default
+  fi
+}
+
+_ll_backend_llm_invoke() {
+  local model="$1"
+  local prompt="$2"
+  llm -m "$model" "$prompt"
+}
+
+# ============================================================
+# Backend auto-selection
+# ============================================================
+_ll_select_backend() {
+  # If user specified a backend, use it
+  if [[ -n "$ZUMMONER_BACKEND" && "$ZUMMONER_BACKEND" != "auto" ]]; then
+    if _ll_backend_${ZUMMONER_BACKEND}_detect 2>/dev/null; then
+      echo "$ZUMMONER_BACKEND"
+      return 0
+    fi
+    return 1
+  fi
+
+  # Otherwise auto-detect by priority
+  for backend in llcat llm lms; do
+    if _ll_backend_${backend}_detect 2>/dev/null; then
+      echo "$backend"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Get model for selected backend
+_ll_get_model() {
+  local backend="$1"
+  _ll_backend_${backend}_model
+}
+
+# Invoke LLM with model and prompt
+_ll_invoke() {
+  local backend="$1"
+  local model="$2"
+  local prompt="$3"
+  _ll_backend_${backend}_invoke "$model" "$prompt"
+}
+
 zummoner() {
   local QUESTION="$BUFFER"
   local PROMPT="
@@ -29,27 +134,22 @@ zummoner() {
   other formatting. Do not include the command into a code block.
   Don't include the shell itself (bash, zsh, etc.) in the command.
   "
-  if which llcat >& /dev/null; then
-    alias _ll="llcat -k $LLC_KEY -u $LLC_SERVER"
-    [[ -n "$LLC_MCP" ]] && _ll="$_ll -mf $LLC_MCP"
-    model="$LLC_MODEL"
-  else
-    alias _ll="llm"
 
-    if [[ -r "$HOME/$config/io.datasette.llm/default_model.txt" ]]; then
-      model=$(cat "$HOME/$config/io.datasette.llm/default_model.txt")
-    else
-      model=$(llm models default)
-    fi
-  fi
+  # Auto-detect and select backend
+  local backend=$(_ll_select_backend) || {
+    BUFFER="No LLM backend found (llcat, lms, or llm)"
+    return 1
+  }
+
+  local model=$(_ll_get_model "$backend")
 
   BUFFER="$QUESTION ... $model"
   zle -R
-  local response=$(_ll -m $model "$PROMPT")
+  local response=$(_ll_invoke "$backend" "$model" "$PROMPT")
   local COMMAND=$(echo "$response" | sed 's/```//g' | tr -d '\n')
   #echo "$(date %s) {$QUESTION | $response}" >> /tmp/zummoner
   if [[ -n "$COMMAND" ]] ; then
-    if [[ -n "$ZUMMONER_SPELL" ]]; then 
+    if [[ -n "$ZUMMONER_SPELL" ]]; then
       [[ "$QUESTION" = *"#"* ]] && QUESTION="${QUESTION#*\# }"
       BUFFER="${COMMAND%%\#*} # $QUESTION"
     else


### PR DESCRIPTION
Appreciate you for implementing such an interesting idea! As an lmstudio user, I think it would provide a smoother experience if it could directly support the lmstudio CLI. If you think that's too much, please feel free to close the PR. 🍻

Changes:

Add support [lmstudio cli](https://lmstudio.ai/docs/cli) support with a modular LLM backend :
    - Backend detection functions for each supported backend
    - Auto-selection logic with priority ordering
    - Configurable backend via ZUMMONER_BACKEND env var
    - Model retrieval per backend